### PR TITLE
Sticker model tests

### DIFF
--- a/stickerz/models.py
+++ b/stickerz/models.py
@@ -12,6 +12,8 @@ class Sticker(models.Model):
     sticker_slug = models.SlugField(unique=True)
 
     def save(self, *args, **kwargs):
+        if self.price < 0:
+            raise ValueError("Price cannot be negative")
         self.sticker_slug = slugify(self.name)
         super(Sticker, self).save(*args, **kwargs)
         # Modified save function to update sticker_slug to be the slugified name of the sticker

--- a/stickerz/sticker_model_test.py
+++ b/stickerz/sticker_model_test.py
@@ -1,0 +1,18 @@
+from django.test import TestCase, RequestFactory
+from unittest.mock import MagicMock, patch
+from stickerz.models import Sticker
+from stickerz.views import sticker
+
+class Sticker_model_tests(TestCase):
+    valid_mock_sticker = Sticker(name="test_1", price=1.00, category="test", sticker_slug="test_1")
+    
+    
+    @patch('stickerz.models.Sticker.save')
+    def test_valid_stickers_get_created(self, valid_mock_sticker):
+        
+        result = Sticker.objects.get_or_create(valid_mock_sticker)
+
+        self.assertTrue(result, True)
+
+
+    

--- a/stickerz/sticker_model_test.py
+++ b/stickerz/sticker_model_test.py
@@ -1,18 +1,47 @@
-from django.test import TestCase, RequestFactory
-from unittest.mock import MagicMock, patch
+from django.test import TestCase
 from stickerz.models import Sticker
-from stickerz.views import sticker
 
 class Sticker_model_tests(TestCase):
-    valid_mock_sticker = Sticker(name="test_1", price=1.00, category="test", sticker_slug="test_1")
-    
-    
-    @patch('stickerz.models.Sticker.save')
-    def test_valid_stickers_get_created(self, valid_mock_sticker):
-        
-        result = Sticker.objects.get_or_create(valid_mock_sticker)
+    def setUp(self):
+        self.valid_sticker_data = {
+            "name": "test 1",
+            "price": 1.00,
+            "category": "test",
+        }
 
-        self.assertTrue(result, True)
+        self.invalid_sticker_data = {
+            "name": "test 2",
+            "price": -1.00,
+            "category": "test",
+        }
+        
+        self.free_sticker_data = {
+            "name": "test 3",
+            "price": 0.00,
+            "category": "test",
+        }
+
+    def test_valid_stickers_get_created(self):
+        sticker, created = Sticker.objects.get_or_create(**self.valid_sticker_data)
+
+        self.assertTrue(created)
+        self.assertEqual(sticker.name, self.valid_sticker_data["name"])
+        self.assertEqual(sticker.price, self.valid_sticker_data["price"])
+        self.assertEqual(sticker.category, self.valid_sticker_data["category"])
+        self.assertEqual(sticker.sticker_slug, "test-1")
+
+
+    def test_invalid_stickers_dont_get_created(self):
+        sticker, created = Sticker.objects.get_or_create(**self.invalid_sticker_data)
+        self.assertFalse(created)
+        #this is currently failing 
+
+
+    def test_free_stickers_can_be_created(self):
+        sticker, created = Sticker.objects.get_or_create(**self.free_sticker_data)
+
+        self.assertTrue(created)
+        self.assertEqual(sticker.price, self.free_sticker_data["price"])
 
 
     

--- a/stickerz/sticker_model_test.py
+++ b/stickerz/sticker_model_test.py
@@ -29,6 +29,8 @@ class Sticker_model_tests(TestCase):
         self.assertEqual(sticker.price, self.valid_sticker_data["price"])
         self.assertEqual(sticker.category, self.valid_sticker_data["category"])
         self.assertEqual(sticker.sticker_slug, "test-1")
+        #return string should be set to the name of the sticker
+        self.assertEqual(sticker.__str__(), "test 1")
 
 
     def test_invalid_stickers_dont_get_created(self):
@@ -44,4 +46,4 @@ class Sticker_model_tests(TestCase):
         self.assertEqual(sticker.price, self.free_sticker_data["price"])
 
 
-    
+        

--- a/stickerz/sticker_model_test.py
+++ b/stickerz/sticker_model_test.py
@@ -34,9 +34,8 @@ class Sticker_model_tests(TestCase):
 
 
     def test_invalid_stickers_dont_get_created(self):
-        sticker, created = Sticker.objects.get_or_create(**self.invalid_sticker_data)
-        self.assertFalse(created)
-        #this is currently failing 
+        with self.assertRaises(ValueError):
+            sticker, created = Sticker.objects.get_or_create(**self.invalid_sticker_data)
 
 
     def test_free_stickers_can_be_created(self):


### PR DESCRIPTION
The coverage might need some improvement so please let me know if I am missing any cases
The linked issues are:

-when attempting to add a sticker, if it is a valid sticker, then it will be created [#34](https://github.com/Emenopi/SuperSillyStickerz/issues/34)
- when adding a sticker, if the price of the sticker is 0, then the sticker will be created (free stickers, yay!)
 [#40](https://github.com/Emenopi/SuperSillyStickerz/issues/40)
- when a valid sticker is created, a the correct slug is generated for that sticker
[#35](https://github.com/Emenopi/SuperSillyStickerz/issues/35)
- when a sticker is created, it will have the correct corresponding string (string should be sticker.name)
[#43](https://github.com/Emenopi/SuperSillyStickerz/issues/43)


